### PR TITLE
Fix image URL in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Hop: A router for Elm SPAs
 
-![alt Hope](./assets/logo.png)
+![alt Hope](https://raw.githubusercontent.com/sporto/hop/master/assets/logo.png)
 
 ## How this works
 


### PR DESCRIPTION
The image is not loading on http://package.elm-lang.org/packages/sporto/hop/1.1.2/

<img width="687" alt="screen shot 2015-12-27 at 19 10 52" src="https://cloud.githubusercontent.com/assets/29062/12010000/24497eb6-acce-11e5-9cae-354c98a04d99.png">
