### PR TITLE
Update more examples for match2 routes

### DIFF
--- a/docs/upgrade-2-to-3.md
+++ b/docs/upgrade-2-to-3.md
@@ -24,10 +24,10 @@ type Route
   | Token String
 ```
 
-Routes are now defined using matchers. So instead of 
+Routes are now defined using matchers. So instead of
 
 ```elm
-routes = 
+routes =
   [ ("/users/:int", User) ]
 ```
 
@@ -37,7 +37,7 @@ You do:
 import Hop.Matchers exposing(match2)
 
 userMatcher =
-  match2 User "/users" int
+  match2 User "/users/" int
 
 matchers =
   [userMatcher]
@@ -102,4 +102,3 @@ case User userId ->
 ```
 
 The query is still a dictionary. The query is now in the `location` record as shown above.
-

--- a/examples/basic/Main.elm
+++ b/examples/basic/Main.elm
@@ -46,13 +46,13 @@ For example:
 
 Will match "/about" and return AboutRoute
 
-    match2 UserRoute "/users" int
+    match2 UserRoute "/users/" int
 
 Will match "/users/1" and return (UserRoute 1)
 
 `int` is a matcher that matches only integers, for a string use `str` e.g.
 
-    match2 UserRoute "/users" str
+    match2 UserRoute "/users/" str
 
 Would match "/users/abc"
 


### PR DESCRIPTION
Found a few more spots where examples of `match2` needed fixing. Other changes are automatic editor changes: trimming spaces at the end of lines.